### PR TITLE
Send content-type header with body

### DIFF
--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -106,7 +106,7 @@ pub trait ApiClient<State> {
 			queryable.url(api_state),
 		);
 		if let Some(body) = queryable.body(api_state) {
-			request = request.body(body?);
+			request = request.body(body?).header("Content-Type", "application/json");
 		}
 
 		Ok(request)


### PR DESCRIPTION
Inside of [lib.rs](https://github.com/onlivfe/racal/blob/f00b697e89c8ebfd552ff5491fe2e6319f7ff413/src/lib.rs#L51) the body function has a comment above it that says "Creates a JSON body" which I think means that it should also send the correct content type header.

I've looked at how reqwest handles this, and they have a dedicated [json function](https://docs.rs/reqwest/latest/reqwest/struct.RequestBuilder.html#method.json) inside of the RequestBuilder which does automatically add the content type header.

