### PR TITLE
Impl thiserror::Error for reqwest::ApiError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ reqwest = ["dep:reqwest", "async-trait"]
 [dependencies]
 serde = "1"
 serde_json = "1"
+thiserror = "1"
 
 async-trait = { version = "0.1", optional = true }
 

--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -6,15 +6,19 @@
 
 use reqwest::{Client, RequestBuilder, Response};
 use serde::de::DeserializeOwned;
+use thiserror::Error;
 
 use crate::{FromApiState, Queryable, RequestMethod};
 
 /// An error that may happen with an API query
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum ApiError {
 	/// An error happened with serialization
+	#[error("An error happened with serialization")]
 	Serde(serde_json::Error),
+
 	/// An error happened with the request itself
+	#[error("An error happened with the request itself")]
 	Reqwest(reqwest::Error),
 }
 

--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -14,11 +14,11 @@ use crate::{FromApiState, Queryable, RequestMethod};
 #[derive(Debug, Error)]
 pub enum ApiError {
 	/// An error happened with serialization
-	#[error("An error happened with serialization")]
+	#[error("An error happened with serialization: {0}")]
 	Serde(serde_json::Error),
 
 	/// An error happened with the request itself
-	#[error("An error happened with the request itself")]
+	#[error("An error happened with the request itself: {0}")]
 	Reqwest(reqwest::Error),
 }
 


### PR DESCRIPTION
I implemented `thiserror::Error` for `reqwest::ApiError` for the `Result` `?` shorthand operator.

EDIT: Since this crate is still pre-v1 and this change is only additional not breaking, it should be `0.3.4`